### PR TITLE
Change print statements to warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "AMPAL"
-version = "1.5.3"
+version = "1.5.4"
 requires-python = ">= 3.8"
 readme = "README.md"
 dependencies = [

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ def readme():
 
 setup(
     name="AMPAL",
-    version="1.5.3",
+    version="1.5.4",
     description="A simple framework for representing biomolecular structure.",
     long_description=readme(),
     long_description_content_type="text/markdown; charset=UTF-8; variant=GFM",

--- a/src/ampal/__init__.py
+++ b/src/ampal/__init__.py
@@ -9,4 +9,4 @@ from .pseudo_atoms import PseudoGroup, PseudoMonomer, PseudoAtom, Primitive
 from .dssp import tag_dssp_data
 
 
-__version__ = "1.5.3"
+__version__ = "1.5.4"

--- a/src/ampal/analyse_protein.py
+++ b/src/ampal/analyse_protein.py
@@ -265,7 +265,7 @@ def measure_torsion_angles(residues):
                         res2["N"]._vector,
                     )
                 except KeyError as k:
-                    print("{0} atom missing - can't assign psi".format(k))
+                    warnings.warn("{0} atom missing - can't assign psi".format(k))
                     psi = None
                 torsion_angles.append((omega, phi, psi))
             elif i == len(residues) - 1:
@@ -279,7 +279,7 @@ def measure_torsion_angles(residues):
                         res2["CA"]._vector,
                     )
                 except KeyError as k:
-                    print("{0} atom missing - can't assign omega".format(k))
+                    warnings.warn("{0} atom missing - can't assign omega".format(k))
                     omega = None
                 try:
                     phi = dihedral(
@@ -289,7 +289,7 @@ def measure_torsion_angles(residues):
                         res2["C"]._vector,
                     )
                 except KeyError as k:
-                    print("{0} atom missing - can't assign phi".format(k))
+                    warnings.warn("{0} atom missing - can't assign phi".format(k))
                     phi = None
                 psi = None
                 torsion_angles.append((omega, phi, psi))
@@ -305,7 +305,7 @@ def measure_torsion_angles(residues):
                         res2["CA"]._vector,
                     )
                 except KeyError as k:
-                    print("{0} atom missing - can't assign omega".format(k))
+                    warnings.warn("{0} atom missing - can't assign omega".format(k))
                     omega = None
                 try:
                     phi = dihedral(
@@ -315,7 +315,7 @@ def measure_torsion_angles(residues):
                         res2["C"]._vector,
                     )
                 except KeyError as k:
-                    print("{0} atom missing - can't assign phi".format(k))
+                    warnings.warn("{0} atom missing - can't assign phi".format(k))
                     phi = None
                 try:
                     psi = dihedral(
@@ -325,7 +325,7 @@ def measure_torsion_angles(residues):
                         res3["N"]._vector,
                     )
                 except KeyError as k:
-                    print("{0} atom missing - can't assign psi".format(k))
+                    warnings.warn("{0} atom missing - can't assign psi".format(k))
                     psi = None
                 torsion_angles.append((omega, phi, psi))
     return torsion_angles


### PR DESCRIPTION
Allows to silence the warnings to avoid being overloaded by print statements. Especially useful in jupyter notebooks.